### PR TITLE
fix: early return if broadcast next is same as current

### DIFF
--- a/packages/react/src/use-qwery/index.tsx
+++ b/packages/react/src/use-qwery/index.tsx
@@ -56,7 +56,10 @@ export const useQwery = <
 			if (broadcast) {
 				const channel = createBroadcastChannel();
 
-				channel?.postMessage(diff(args[0], args[1]));
+				channel?.postMessage({
+					next: args[0],
+					previous: args[1],
+				});
 				channel?.close();
 			}
 
@@ -217,19 +220,17 @@ export const useQwery = <
 		const channel = createBroadcastChannel();
 
 		const onBroadcast = async (
-			event: BroadcastChannelEventMap["message"],
+			event: MessageEvent<{ next: D; previous: D }>,
 		) => {
 			const updates = event.data;
 
 			const crdt = await crdtRef.current;
 
-			crdt?.dispatch(
-				previousValue => ({
-					...previousValue,
-					...updates,
-				}),
-				{ isPersisted: true },
-			);
+			if (updates.next === crdt?.data) {
+				return;
+			}
+
+			crdt?.dispatch(updates.next, { isPersisted: true });
 
 			setRenderCount(renderCount => renderCount + 1);
 		};

--- a/packages/react/src/use-qwery/index.tsx
+++ b/packages/react/src/use-qwery/index.tsx
@@ -221,6 +221,8 @@ export const useQwery = <
 
 			const crdt = await crdtRef.current;
 
+			// `onChange` will trigger this listener even if on the same tab
+			// in that case early return
 			if (next === crdt?.data) {
 				return;
 			}

--- a/packages/react/src/use-qwery/index.tsx
+++ b/packages/react/src/use-qwery/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { type CRDT, createCRDT, diff } from "@b.s/incremental";
+import { type CRDT, createCRDT } from "@b.s/incremental";
 import { QweryContext } from "../context";
 import { useRememberScroll } from "../use-remember-scroll";
 import type {

--- a/packages/react/src/use-qwery/index.tsx
+++ b/packages/react/src/use-qwery/index.tsx
@@ -56,10 +56,7 @@ export const useQwery = <
 			if (broadcast) {
 				const channel = createBroadcastChannel();
 
-				channel?.postMessage({
-					next: args[0],
-					previous: args[1],
-				});
+				channel?.postMessage(args[0]);
 				channel?.close();
 			}
 
@@ -219,18 +216,16 @@ export const useQwery = <
 	React.useEffect(() => {
 		const channel = createBroadcastChannel();
 
-		const onBroadcast = async (
-			event: MessageEvent<{ next: D; previous: D }>,
-		) => {
-			const updates = event.data;
+		const onBroadcast = async (event: MessageEvent<D>) => {
+			const next = event.data;
 
 			const crdt = await crdtRef.current;
 
-			if (updates.next === crdt?.data) {
+			if (next === crdt?.data) {
 				return;
 			}
 
-			crdt?.dispatch(updates.next, { isPersisted: true });
+			crdt?.dispatch(next, { isPersisted: true });
 
 			setRenderCount(renderCount => renderCount + 1);
 		};


### PR DESCRIPTION
all listening channels receive a message even if on the same tab, and just reset to the next broadcasted state because otherwise we gotta determine if its an array and all

same pc so no multiple users sending messages concurrently problem. ~~unless subscriptions~~ subscriptions have `isPersisted` which does not trigger `onChange` so won't send a message out