### PR TITLE
feat: add map reduce and maybe return a promise utility fn 

### DIFF
--- a/packages/shared/src/use-qwery/index.ts
+++ b/packages/shared/src/use-qwery/index.ts
@@ -1,1 +1,31 @@
 export * from "./types";
+
+export const mapReduceMaybePromise =
+	<Fns extends Fn[]>(fns: Fns) =>
+	(...args: any[]): MaybePromise<SomeReturnsPromise<Fns[number]>> => {
+		const reduced = fns.reduce(
+			(acc, fn) => {
+				const result = fn(...args);
+
+				return {
+					hasPromise: acc.hasPromise || result instanceof Promise,
+					results: [...acc.results, result],
+				};
+			},
+			{ results: [] as any[], hasPromise: false },
+		);
+
+		if (reduced.hasPromise) {
+			return Promise.allSettled(reduced.results) as any;
+		}
+
+		return reduced.results as any;
+	};
+
+type Fn = (...args: any[]) => any;
+type SomeReturnsPromise<T> = T extends (...args: any[]) => infer R
+	? R extends Promise<any>
+		? true
+		: never
+	: never;
+type MaybePromise<P> = P extends true ? Promise<void> : void;


### PR DESCRIPTION
for change handlers

`mapReduceMaybePromise([() => null, (...args) => Promise.resolve()])()` results in `Promise<void>`
`mapReduceMaybePromise([() => null])(...args)` results in `never`
